### PR TITLE
fix(orders): use hardcoded user ID for order creation

### DIFF
--- a/src/pages/cart/CartPage.jsx
+++ b/src/pages/cart/CartPage.jsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { useCart, useCartDispatch } from "../../context/CartContext";
 import { createOrder } from "../../api/ordersApi";
-import { DUMMY_USER_ID } from "../../data/dummyProducts";
+import { CARDS_USER_ID } from "../../data/dummyProducts";
 
 export default function CartPage() {
   const { items } = useCart();
@@ -15,7 +15,7 @@ export default function CartPage() {
     if (!items.length) return;
 
     const order = {
-      createdBy: DUMMY_USER_ID,
+      createdBy: CARDS_USER_ID,
       items: items.map(i => ({
         productId: i.productId,
         productName: i.productName,


### PR DESCRIPTION

<img width="591" height="171" alt="{617A762D-30FA-4D6D-939D-E5652C784D1C}" src="https://github.com/user-attachments/assets/d2f2882a-34c8-41c3-ab31-1ae47bf846e4" />
Diagnosis: Orders were failing to create because they used the dynamic DUMMY_USER_ID which doesn't exist in the database. The orders API requires an existing user ID to successfully create orders. Resolution: Updated CartPage to use CARDS_USER_ID (the hardcoded user that exists in the database) for order creation, ensuring orders can be successfully processed by the backend API.